### PR TITLE
Add Volume Controller

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -100,6 +100,41 @@ fn handle_command(key_name: &str) -> bool {
             .arg("85")
             .join()
             .is_ok(),
+        "volup" => Exec::cmd("adb")
+            .arg("shell")
+            .arg("input")
+            .arg("keyevent")
+            .arg("24")
+            .join()
+            .is_ok(),
+        "voldown" => Exec::cmd("adb")
+            .arg("shell")
+            .arg("input")
+            .arg("keyevent")
+            .arg("25")
+            .join()
+            .is_ok(),
+        "mute" => Exec::cmd("adb")
+            .arg("shell")
+            .arg("input")
+            .arg("keyevent")
+            .arg("164")
+            .join()
+            .is_ok(),
+        "volmax" => Exec::cmd("adb")
+            .arg("shell")
+            .arg("media")
+            .arg("volume")
+            .arg("--set 15")
+            .join()
+            .is_ok(),
+        "volmin" => Exec::cmd("adb")
+            .arg("shell")
+            .arg("media")
+            .arg("volume")
+            .arg("--set 1")
+            .join()
+            .is_ok(),            
         _ => false,
     }
 }


### PR DESCRIPTION
I loved the simplicity of your code. I was looking for an application to increase FireTV volume and easy to use.

volup -> Increases volume
voldown -> lowers volume
mute -> idem
volmax -> Set Volume to Max
volmin -> Set volume to min. 

This feature resolves a problem when connecting Echo Dot to FireTV and FireTV volume is at least. 

https://www.amazonforum.com/s/question/0D54P00008SKYZp/fire-tv-stick-lite-low-volume-when-connecting-to-bluetooth-speaker